### PR TITLE
distinguish mystics by max lives

### DIFF
--- a/apiTools/mysticLogging.js
+++ b/apiTools/mysticLogging.js
@@ -164,6 +164,7 @@ const logMystics = async (owner, items) => {
         dups_loop:
         for(const m of dups){
             if(m.tier === mystic.tier){
+                if(m.maxLives !== mystic.maxLives) continue;
                 if(m.enchants.length !== mystic.enchants.length) continue;
                 let delta = 0;
                 for(let i = 0; i < m.enchants.length; i++){


### PR DESCRIPTION
Pit Panda attempts to distinguish different mystics by data such as their nonce and enchants. The nonce is usually unique but sometimes there are multiple mystics with the same nonce (sometimes dozens). Pit Panda currently does not distinguish different mystics by their max lives. The max lives of a mystic can never change unless the mystic also changes tier, which is already a handled case. We can therefore use the max lives to better distinguish different mystics.